### PR TITLE
Fix typesVersions path mapping

### DIFF
--- a/packages/solid-styled/package.json
+++ b/packages/solid-styled/package.json
@@ -61,7 +61,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "./dist/types/index.d.ts"
+        "./dist/types/*"
       ]
     }
   }


### PR DESCRIPTION
Thanks for this awesome library!

I've been running into an issue where vscode adds auto-imports like `import { css } from 'solid-styled/*'` instead of `import { css } from 'solid-styled'`. This change seems to fix it.