### PR TITLE
Fix query selector should use escaped id

### DIFF
--- a/packages/solid-styled/src/core.ts
+++ b/packages/solid-styled/src/core.ts
@@ -49,7 +49,7 @@ function remove(id: string) {
     references.set(id, count - 1);
   } else {
     references.set(id, 0);
-    const node = document.head.querySelector(`style[${SOLID_SHEET_ATTR}="${id}"]`);
+    const node = document.head.querySelector(`style[${SOLID_SHEET_ATTR_ESCAPED}="${id}"]`);
     if (node) {
       document.head.removeChild(node);
     }


### PR DESCRIPTION
Probably just a typo, but without this change HMR/page refreshes break for me when using Solid Start