### PR TITLE
docs(README): Add more extensions for filter paths

### DIFF
--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -28,8 +28,8 @@ solidStyled({
   verbose: true, // defaults to false
   prefix: 'my-prefix', // optional
   filter: {
-    include: 'src/**/*.ts',
-    exclude: 'node_modules/**/*.{ts,js}',
+    include: 'src/**/*.{ts,js,tsx,jsx}',
+    exclude: 'node_modules/**/*.{ts,js,tsx,jsx}',
   },
 })
 ```

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -31,8 +31,8 @@ export default {
     solidStyled({
       prefix: 'my-prefix', // optional
       filter: {
-        include: 'src/**/*.ts',
-        exclude: 'node_modules/**/*.{ts,js}',
+        include: 'src/**/*.{ts,js,tsx,jsx}',
+        exclude: 'node_modules/**/*.{ts,js,tsx,jsx}',
       },
     }),
   ]


### PR DESCRIPTION
Hey there! I tried to add `solid-styled` to my vite project and copy-pasted code from vite integration docs, but it turns out that it lacks `tsx` and `jsx` extensions. I thought that it would be great if we add them, because they are very common.

This PR adds those extensions to bundler integrations `README`

Thank you for an awesome library ❤️ 