### PR TITLE
Adjust pnpm-lock.yaml to fix CI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         specifier: ^1.6.16
         version: 1.6.16
       solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.0
         version: link:../../packages/solid-styled
     devDependencies:
       astro:
@@ -42,7 +42,7 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       unplugin-solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.1
         version: link:../../packages/unplugin
 
   examples/demo:
@@ -51,7 +51,7 @@ importers:
         specifier: ^1.6.16
         version: 1.6.16
       solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.0
         version: link:../../packages/solid-styled
     devDependencies:
       eslint:
@@ -64,7 +64,7 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       unplugin-solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.1
         version: link:../../packages/unplugin
       vite:
         specifier: ^4.2.1
@@ -79,7 +79,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2(rollup@3.5.1)
       unplugin-solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.1
         version: link:../unplugin
     devDependencies:
       '@types/node':
@@ -98,7 +98,7 @@ importers:
         specifier: ^3.5.1
         version: 3.5.1
       solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.0
         version: link:../solid-styled
       tslib:
         specifier: ^2.5.0
@@ -187,7 +187,7 @@ importers:
         specifier: 2.4.2
         version: 2.4.2(eslint@8.36.0)(tslib@2.5.0)(typescript@4.9.5)
       solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.0
         version: link:../solid-styled
       tslib:
         specifier: ^2.5.0
@@ -205,7 +205,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2(rollup@3.5.1)
       unplugin-solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.1
         version: link:../unplugin
     devDependencies:
       '@types/node':
@@ -221,7 +221,7 @@ importers:
         specifier: 2.4.2
         version: 2.4.2(eslint@8.36.0)(tslib@2.5.0)(typescript@4.9.5)
       solid-styled:
-        specifier: 0.8.2
+        specifier: 0.9.0
         version: link:../solid-styled
       tslib:
         specifier: ^2.5.0


### PR DESCRIPTION
Whenever a `package.json` file is edited (even if only to bump the version number), `pnpm-lock.yaml` needs to be adjusted by running `pnpm install`, so that `--frozen-lockfile` keeps working in CI, and also so that other contributors running `pnpm install` don’t end up with extraneous changes.