### PR TITLE
feat: new jsx global

### DIFF
--- a/packages/solid-styled/compiler/core/constants.ts
+++ b/packages/solid-styled/compiler/core/constants.ts
@@ -12,4 +12,5 @@ export const RUNTIME_IDENTIFIERS = {
   createCSSVars: 'createCSSVars',
   mergeStyles: 'mergeStyles',
   useSolidStyled: 'useSolidStyled',
+  useSolidStyledGlobal: 'useSolidStyledGlobal',
 };

--- a/packages/solid-styled/compiler/core/process-css-template.ts
+++ b/packages/solid-styled/compiler/core/process-css-template.ts
@@ -1,7 +1,7 @@
 import * as t from '@babel/types';
 import type { StateContext } from '../types';
 import preprocessCSS from './preprocess-css';
-import processScopedSheet from './process-scoped-sheet';
+import processScopedSheet from './process-scoped-sheet.old';
 import { getPrefix, getUniqueId } from './utils';
 
 interface DynamicTemplateResult {
@@ -52,10 +52,11 @@ export default function processCSSTemplate(
 ): DynamicTemplateResult {
   // Replace the template's dynamic parts with CSS variables
   const { sheet, variables } = replaceDynamicTemplate(ctx, templateLiteral);
+  const preprocessed = preprocessCSS(ctx, sheet);
   return {
     sheet: isScoped
-      ? processScopedSheet(ctx, sheetID, sheet)
-      : preprocessCSS(ctx, sheet),
+      ? preprocessCSS(ctx, processScopedSheet(ctx, sheetID, preprocessed))
+      : preprocessed,
     variables,
   };
 }

--- a/packages/solid-styled/compiler/core/process-scoped-sheet.old.ts
+++ b/packages/solid-styled/compiler/core/process-scoped-sheet.old.ts
@@ -1,10 +1,14 @@
 import * as csstree from 'css-tree';
 import { GLOBAL_SELECTOR, SOLID_STYLED_NS } from './constants';
+import type { StateContext } from '../types';
 
 export default function processScopedSheet(
+  ctx: StateContext,
   sheetID: string,
-  ast: csstree.CssNode,
-): void {
+  content: string,
+): string {
+  console.log(content);
+  const ast = csstree.parse(content);
   // This selector is going to be inserted
   // on every non-global selector
   // [s\:${sheetID}]
@@ -173,4 +177,6 @@ export default function processScopedSheet(
       }
     },
   });
+
+  return csstree.generate(ast);
 }

--- a/packages/solid-styled/compiler/plugin.ts
+++ b/packages/solid-styled/compiler/plugin.ts
@@ -260,10 +260,7 @@ function processJSXTemplate(
           sheet.count = current;
 
           const computedVars = variables.length
-            ? t.callExpression(
-              generateVars(ctx, path, functionParent),
-              [t.arrowFunctionExpression([], t.objectExpression(variables))],
-            )
+            ? t.arrowFunctionExpression([], t.objectExpression(variables))
             : undefined;
           if (isGlobal) {
             const args: t.Expression[] = [
@@ -293,7 +290,10 @@ function processJSXTemplate(
             );
             statement.insertBefore(t.expressionStatement(
               computedVars
-                ? t.sequenceExpression([setup, computedVars])
+                ? t.sequenceExpression([setup, t.callExpression(
+                  generateVars(ctx, path, functionParent),
+                  [computedVars],
+                )])
                 : setup,
             ));
           }

--- a/packages/solid-styled/compiler/plugin.ts
+++ b/packages/solid-styled/compiler/plugin.ts
@@ -259,11 +259,9 @@ function processJSXTemplate(
           const current = sheet.count + 1;
           sheet.count = current;
 
-          const vars = generateVars(ctx, path, functionParent);
-
           const computedVars = variables.length
             ? t.callExpression(
-              vars,
+              generateVars(ctx, path, functionParent),
               [t.arrowFunctionExpression([], t.objectExpression(variables))],
             )
             : undefined;

--- a/packages/solid-styled/test/__snapshots__/jsx.test.ts.snap
+++ b/packages/solid-styled/test/__snapshots__/jsx.test.ts.snap
@@ -2,15 +2,13 @@
 
 exports[`jsx > should transform 1`] = `
 "import { useSolidStyled as _useSolidStyled } from \\"solid-styled\\";
-import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
 const _sheet = \\"c-f0b3b6fa-0\\";
 const _css = \\"h1[s\\\\\\\\:c-f0b3b6fa-0]{color:red}\\";
 export default function Example() {
-  const _vars = _createCSSVars();
   _useSolidStyled(_sheet, 1, _css);
   return <>
       
-      <h1 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h1>
+      <h1 s:c-f0b3b6fa-0>Hello World</h1>
     </>;
 }"
 `;
@@ -34,34 +32,30 @@ export default function Example() {
 
 exports[`jsx > should work with multiple templates 1`] = `
 "import { useSolidStyled as _useSolidStyled } from \\"solid-styled\\";
-import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
 const _sheet = \\"c-f0b3b6fa-0\\";
 const _css = \\"h1[s\\\\\\\\:c-f0b3b6fa-0]{color:red}\\";
 const _css2 = \\"h2[s\\\\\\\\:c-f0b3b6fa-0]{color:#00f}\\";
 export default function Example() {
-  const _vars = _createCSSVars();
   _useSolidStyled(_sheet, 1, _css);
   _useSolidStyled(_sheet, 2, _css2);
   return <>
       
-      <h1 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h1>
+      <h1 s:c-f0b3b6fa-0>Hello World</h1>
       
-      <h2 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h2>
+      <h2 s:c-f0b3b6fa-0>Hello World</h2>
     </>;
 }"
 `;
 
 exports[`jsx.global > should transform 1`] = `
 "import { useSolidStyledGlobal as _useSolidStyledGlobal } from \\"solid-styled\\";
-import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
 const _sheet = \\"c-f0b3b6fa-0\\";
 const _css = \\"h1{color:red}\\";
 export default function Example() {
-  const _vars = _createCSSVars();
   _useSolidStyledGlobal(_sheet, 1, _css);
   return <>
       
-      <h1 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h1>
+      <h1 s:c-f0b3b6fa-0>Hello World</h1>
     </>;
 }"
 `;
@@ -85,19 +79,17 @@ export default function Example() {
 
 exports[`jsx.global > should work with multiple templates 1`] = `
 "import { useSolidStyledGlobal as _useSolidStyledGlobal } from \\"solid-styled\\";
-import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
 const _sheet = \\"c-f0b3b6fa-0\\";
 const _css = \\"h1{color:red}\\";
 const _css2 = \\"h2{color:#00f}\\";
 export default function Example() {
-  const _vars = _createCSSVars();
   _useSolidStyledGlobal(_sheet, 1, _css);
   _useSolidStyledGlobal(_sheet, 2, _css2);
   return <>
       
-      <h1 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h1>
+      <h1 s:c-f0b3b6fa-0>Hello World</h1>
       
-      <h2 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h2>
+      <h2 s:c-f0b3b6fa-0>Hello World</h2>
     </>;
 }"
 `;

--- a/packages/solid-styled/test/__snapshots__/jsx.test.ts.snap
+++ b/packages/solid-styled/test/__snapshots__/jsx.test.ts.snap
@@ -50,3 +50,54 @@ export default function Example() {
     </>;
 }"
 `;
+
+exports[`jsx.global > should transform 1`] = `
+"import { useSolidStyledGlobal as _useSolidStyledGlobal } from \\"solid-styled\\";
+import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
+const _sheet = \\"c-f0b3b6fa-0\\";
+const _css = \\"h1{color:red}\\";
+export default function Example() {
+  const _vars = _createCSSVars();
+  _useSolidStyledGlobal(_sheet, 1, _css);
+  return <>
+      
+      <h1 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h1>
+    </>;
+}"
+`;
+
+exports[`jsx.global > should transform dynamic templates 1`] = `
+"import { useSolidStyledGlobal as _useSolidStyledGlobal } from \\"solid-styled\\";
+import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
+const _sheet = \\"c-f0b3b6fa-0\\";
+const _css = \\"h1{color:var(--s-v-f0b3b6fa-1)}\\";
+export default function Example() {
+  const _vars = _createCSSVars();
+  _useSolidStyledGlobal(_sheet, 1, _css, _vars(() => ({
+    \\"--s-v-f0b3b6fa-1\\": props.color
+  })));
+  return <>
+          
+          <h1 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h1>
+        </>;
+}"
+`;
+
+exports[`jsx.global > should work with multiple templates 1`] = `
+"import { useSolidStyledGlobal as _useSolidStyledGlobal } from \\"solid-styled\\";
+import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
+const _sheet = \\"c-f0b3b6fa-0\\";
+const _css = \\"h1{color:red}\\";
+const _css2 = \\"h2{color:#00f}\\";
+export default function Example() {
+  const _vars = _createCSSVars();
+  _useSolidStyledGlobal(_sheet, 1, _css);
+  _useSolidStyledGlobal(_sheet, 2, _css2);
+  return <>
+      
+      <h1 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h1>
+      
+      <h2 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h2>
+    </>;
+}"
+`;

--- a/packages/solid-styled/test/__snapshots__/jsx.test.ts.snap
+++ b/packages/solid-styled/test/__snapshots__/jsx.test.ts.snap
@@ -14,8 +14,8 @@ export default function Example() {
 `;
 
 exports[`jsx > should transform dynamic templates 1`] = `
-"import { useSolidStyled as _useSolidStyled } from \\"solid-styled\\";
-import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
+"import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
+import { useSolidStyled as _useSolidStyled } from \\"solid-styled\\";
 const _sheet = \\"c-f0b3b6fa-0\\";
 const _css = \\"h1[s\\\\\\\\:c-f0b3b6fa-0]{color:var(--s-v-f0b3b6fa-1)}\\";
 export default function Example() {
@@ -62,17 +62,15 @@ export default function Example() {
 
 exports[`jsx.global > should transform dynamic templates 1`] = `
 "import { useSolidStyledGlobal as _useSolidStyledGlobal } from \\"solid-styled\\";
-import { createCSSVars as _createCSSVars } from \\"solid-styled\\";
 const _sheet = \\"c-f0b3b6fa-0\\";
 const _css = \\"h1{color:var(--s-v-f0b3b6fa-1)}\\";
 export default function Example() {
-  const _vars = _createCSSVars();
-  _useSolidStyledGlobal(_sheet, 1, _css, _vars(() => ({
+  _useSolidStyledGlobal(_sheet, 1, _css, () => ({
     \\"--s-v-f0b3b6fa-1\\": props.color
-  })));
+  }));
   return <>
           
-          <h1 s:c-f0b3b6fa-0 style={_vars()}>Hello World</h1>
+          <h1 s:c-f0b3b6fa-0>Hello World</h1>
         </>;
 }"
 `;

--- a/packages/solid-styled/test/jsx.test.ts
+++ b/packages/solid-styled/test/jsx.test.ts
@@ -75,3 +75,70 @@ export default function Example() {
     expect((await compile(FILE, code, options)).code).toMatchSnapshot();
   });
 });
+describe('jsx.global', () => {
+  it('should transform', async () => {
+    const code = `
+export default function Example() {
+  return (
+    <>
+      <style jsx global>
+        {\`
+          h1 {
+            color: red;
+          }
+        \`}
+      </style>
+      <h1>Hello World</h1>
+    </>
+  );
+}
+  `;
+    expect((await compile(FILE, code, options)).code).toMatchSnapshot();
+  });
+  it('should work with multiple templates', async () => {
+    const code = `
+export default function Example() {
+  return (
+    <>
+      <style jsx global>
+        {\`
+          h1 {
+            color: red;
+          }
+        \`}
+      </style>
+      <h1>Hello World</h1>
+      <style jsx global>
+        {\`
+          h2 {
+            color: blue;
+          }
+        \`}
+      </style>
+      <h2>Hello World</h2>
+    </>
+  );
+}
+  `;
+    expect((await compile(FILE, code, options)).code).toMatchSnapshot();
+  });
+  it('should transform dynamic templates', async () => {
+    const code = `
+    export default function Example() {
+      return (
+        <>
+          <style jsx global>
+            {\`
+              h1 {
+                color: \${props.color};
+              }
+            \`}
+          </style>
+          <h1>Hello World</h1>
+        </>
+      );
+    }
+  `;
+    expect((await compile(FILE, code, options)).code).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
- `<style jsx global>` now has a different behavior
  - When provided with dynamic values, previously it would be included to the scoped variables, which is "counter-intuitive" towards its behavior. Now, the dynamic variables are now inserted directly to the document (in CSS, this would be `:root`. The new behavior is also SSR-friendly, as the variables are generated with `:root` style and inserted alongside the accompanied style sheet.
   - Internally, this introduces a new primitive called `useSolidStyledGlobal`.
   - Fixes #28 
   - Since `:global` and `@global` are still declared in a "local sheet", their behavior will remain as-is. In the future, this behavior might be fixed for consistency.
- Fix vars declaration to only generate if there's actually any dynamic styles.
- Fix `@global` (Fixes #18)