### PR TITLE
fix: Update `transformInclude` to filter query strings out of paths

### DIFF
--- a/packages/solid-styled/compiler/index.ts
+++ b/packages/solid-styled/compiler/index.ts
@@ -27,7 +27,7 @@ export async function compile(
   const plugins: NonNullable<
     NonNullable<babel.TransformOptions['parserOpts']>['plugins']
   > = ['jsx'];
-  if (/\.[mc]?tsx?$/i.test(id)) {
+  if (/\.[mc]?tsx?$/i.test(id.split("?")[0])) {
     plugins.push('typescript');
   }
   const result = await babel.transformAsync(code, {

--- a/packages/solid-styled/compiler/index.ts
+++ b/packages/solid-styled/compiler/index.ts
@@ -27,7 +27,7 @@ export async function compile(
   const plugins: NonNullable<
     NonNullable<babel.TransformOptions['parserOpts']>['plugins']
   > = ['jsx'];
-  if (/\.[mc]?tsx?$/i.test(id.split("?")[0])) {
+  if (/\.[mc]?tsx?$/i.test(id.split('?')[0])) {
     plugins.push('typescript');
   }
   const result = await babel.transformAsync(code, {

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -57,7 +57,7 @@ const solidStyledPlugin = createUnplugin(
     return {
       name: 'solid-styled',
       transformInclude(id): boolean {
-        return filter(id);
+        return filter(id.split('?')[0]);
       },
       async transform(code, id): Promise<TransformResult> {
         return compile(id, code, {


### PR DESCRIPTION
SolidStart page routes use query strings which leads to false negatives in the include filter. Fixes #35 